### PR TITLE
Update alt text for Railstats image

### DIFF
--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -3,7 +3,7 @@ identification: '155295655'
 title: Railstats LA
 description: Railstats LA tracks LA Metro trains and generates punctuality reports. Our website enables both Metro officials and the public to easily review up-to-date statistics for LA's 6 train lines.
 image: /assets/images/projects/metro-ontime.png
-alt: 'LA Metro Rail logo'
+alt: 'Railstats LA'
 image-hero: /assets/images/projects/metro-ontime-hero.png
 leadership:
   - name: Cameron Sexton


### PR DESCRIPTION
Fixes #4045

### What changes did you make and why did you make them ?

  - Updated alt text on the Railstats LA page to adhere to the Web Content Accessibility Guidelines (WCAG)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="999" alt="Screenshot 2023-03-02 at 8 38 38 PM" src="https://user-images.githubusercontent.com/97621864/222637530-9e1d07c6-ddd9-4833-a9c3-69e60380a5da.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="933" alt="Screenshot 2023-03-02 at 8 46 08 PM" src="https://user-images.githubusercontent.com/97621864/222637556-86caef12-39de-44d2-9b74-63907656cc99.png">

</details>
